### PR TITLE
Defined TypeView model class | registered route to '/types'

### DIFF
--- a/rockapi/views/__init__.py
+++ b/rockapi/views/__init__.py
@@ -1,1 +1,2 @@
 from .auth import login_user, register_user
+from .types import TypeView

--- a/rockapi/views/types.py
+++ b/rockapi/views/types.py
@@ -1,0 +1,37 @@
+"""View module for handling requests for type data"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from rockapi.models import Type
+
+class TypeView(ViewSet):
+    """Rock API types view"""
+
+    def list(self, request):
+        """Handle GET requests to get all types
+        
+        Returns:
+            Response -- JSON serialized list of types
+        """
+
+        types = Type.objects.all()
+        serialized = TypeSerializer(types, many=True)
+        return Response(serialized.data, status=status.HTTP_200_OK)
+    
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for a single type
+        
+        Returns:
+            Response -- JSON serialized type record
+        """
+
+        rock_type = Type.objects.get()
+        serialized = TypeSerializer(rock_type, many=True)
+        return Response(serialized.data, status=status.HTTP_200_OK)
+    
+class TypeSerializer(serializers.ModelSerializer):
+    """JSON serializer for types"""
+    class Meta:
+        model = Type
+        fields = ( 'id', 'label', )

--- a/rockproject/urls.py
+++ b/rockproject/urls.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from rockapi.views import register_user, login_user
+from rockapi.views import register_user, login_user, TypeView
 
 router = routers.DefaultRouter(trailing_slash=False)
+router.register('types', TypeView, 'type')
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
## Changes

- Defined TypeView() class in views/types.py module
- This class inherits from the ViewSet class imported from rest_framework.viewsets
- Imported the TypeView class into the views package
- Registered route to `/types` in urls.py

## Testing via Postman
GET request to `/types` to return all serialized type objects from the database
**Request**
Send in request body:
```json
{
     "Authorization": "Token {token}"
}
```
**Response**
Returns 200 OK Status with an empty array (since no Type resources exist in the database yet)
```json
[]
```