### PR TITLE
Rocks viewset

### DIFF
--- a/rockapi/views/__init__.py
+++ b/rockapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .auth import login_user, register_user
 from .types import TypeView
+from .rocks import RockView

--- a/rockapi/views/rocks.py
+++ b/rockapi/views/rocks.py
@@ -1,0 +1,39 @@
+from django.http import HttpResponseServerError
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+from rockapi.models import Rock
+
+class RockView(ViewSet):
+    """Rock view set"""
+
+    def create(self, request):
+        """Handle POST operations
+
+        Returns:
+            Response -- JSON serialized instance of a Rock object
+        """
+
+        # You will implement this feature in a future chapter
+        return Response("", status=status.HTTP_405_METHOD_NOT_ALLOWED)
+    
+    def list(self, request):
+        """Handle GET requests for all rock instances
+        
+        Returns:
+            Response -- JSON serialized array
+        """
+
+        try:
+            rocks = Rock.objects.all()
+            serializer = RockSerializer(rocks, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+class RockSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    class Meta:
+        model = Rock
+        fields = ( 'id', 'name', 'weight', )

--- a/rockproject/urls.py
+++ b/rockproject/urls.py
@@ -1,10 +1,14 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from rockapi.views import register_user, login_user, TypeView
+from rockapi.views import (
+    register_user, login_user, 
+    TypeView, RockView
+)
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register('types', TypeView, 'type')
+router.register('rocks', RockView, "rock")
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
## Changes

- Defined RockView() model class in views/rocks.py file that inherits from the ViewSet class imported from rest_framework.viewsets
- Imported the RockView class into the views package
- Registered route to `/rocks` in urls.py

## Testing via Postman
GET requests to `/rocks`
**Request**
Send authorization token in request headers:
```json
{
     "Authorization": "Token {token}"
}
```
**Response**
200 OK status with empty list in response body (since no Rock resource data exists in the database yet)
```json
[]
```