### PR TITLE
Expanded rock types

### DIFF
--- a/rockapi/fixtures/rocks.json
+++ b/rockapi/fixtures/rocks.json
@@ -1,0 +1,32 @@
+[
+    {
+        "model": "rockapi.rock",
+        "pk": 1,
+        "fields": {
+            "user": 1,
+            "type": 3,
+            "name": "Tiana",
+            "weight": 1.3
+        }
+    },
+    {
+        "model": "rockapi.rock",
+        "pk": 2,
+        "fields": {
+            "user": 1,
+            "type": 1,
+            "name": "Orpha",
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "rockapi.rock",
+        "pk": 3,
+        "fields": {
+            "user": 1,
+            "type": 5,
+            "name": "Sasha",
+            "weight": 0.29
+        }
+    }
+]

--- a/rockapi/fixtures/types.json
+++ b/rockapi/fixtures/types.json
@@ -1,0 +1,37 @@
+[
+    {
+        "model": "rockapi.type",
+        "pk": 1,
+        "fields": {
+            "label": "Metamorphic"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 2,
+        "fields": {
+            "label": "Igneous"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 3,
+        "fields": {
+            "label": "Sedimentary"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 4,
+        "fields": {
+            "label": "Shale"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 5,
+        "fields": {
+            "label": "Basalt"
+        }
+    }
+]

--- a/rockapi/views/__init__.py
+++ b/rockapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .auth import login_user, register_user
 from .types import TypeView
+from .rocks import RockView

--- a/rockapi/views/__init__.py
+++ b/rockapi/views/__init__.py
@@ -1,1 +1,2 @@
 from .auth import login_user, register_user
+from .types import TypeView

--- a/rockapi/views/rocks.py
+++ b/rockapi/views/rocks.py
@@ -1,0 +1,39 @@
+from django.http import HttpResponseServerError
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+from rockapi.models import Rock
+
+class RockView(ViewSet):
+    """Rock view set"""
+
+    def create(self, request):
+        """Handle POST operations
+
+        Returns:
+            Response -- JSON serialized instance of a Rock object
+        """
+
+        # You will implement this feature in a future chapter
+        return Response("", status=status.HTTP_405_METHOD_NOT_ALLOWED)
+    
+    def list(self, request):
+        """Handle GET requests for all rock instances
+        
+        Returns:
+            Response -- JSON serialized array
+        """
+
+        try:
+            rocks = Rock.objects.all()
+            serializer = RockSerializer(rocks, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+class RockSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    class Meta:
+        model = Rock
+        fields = ( 'id', 'name', 'weight', )

--- a/rockapi/views/rocks.py
+++ b/rockapi/views/rocks.py
@@ -2,7 +2,7 @@ from django.http import HttpResponseServerError
 from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from rockapi.models import Rock
+from rockapi.models import Rock, Type
 
 class RockView(ViewSet):
     """Rock view set"""
@@ -31,9 +31,18 @@ class RockView(ViewSet):
         except Exception as ex:
             return HttpResponseServerError(ex)
 
-class RockSerializer(serializers.ModelSerializer):
+class RockTypeSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
     class Meta:
+        model = Type
+        fields = ( 'label', )
+
+class RockSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    type = RockTypeSerializer(many=False)
+
+    class Meta:
         model = Rock
-        fields = ( 'id', 'name', 'weight', )
+        fields = ( 'id', 'name', 'weight', 'user', 'type', )

--- a/rockapi/views/types.py
+++ b/rockapi/views/types.py
@@ -1,0 +1,37 @@
+"""View module for handling requests for type data"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from rockapi.models import Type
+
+class TypeView(ViewSet):
+    """Rock API types view"""
+
+    def list(self, request):
+        """Handle GET requests to get all types
+        
+        Returns:
+            Response -- JSON serialized list of types
+        """
+
+        types = Type.objects.all()
+        serialized = TypeSerializer(types, many=True)
+        return Response(serialized.data, status=status.HTTP_200_OK)
+    
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for a single type
+        
+        Returns:
+            Response -- JSON serialized type record
+        """
+
+        rock_type = Type.objects.get()
+        serialized = TypeSerializer(rock_type, many=True)
+        return Response(serialized.data, status=status.HTTP_200_OK)
+    
+class TypeSerializer(serializers.ModelSerializer):
+    """JSON serializer for types"""
+    class Meta:
+        model = Type
+        fields = ( 'id', 'label', )

--- a/rockproject/urls.py
+++ b/rockproject/urls.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from rockapi.views import register_user, login_user
+from rockapi.views import register_user, login_user, TypeView
 
 router = routers.DefaultRouter(trailing_slash=False)
+router.register('types', TypeView, 'type')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rockproject/urls.py
+++ b/rockproject/urls.py
@@ -1,10 +1,14 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from rockapi.views import register_user, login_user, TypeView
+from rockapi.views import (
+    register_user, login_user, 
+    TypeView, RockView
+)
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register('types', TypeView, 'type')
+router.register('rocks', RockView, "rock")
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
## Changes

- Created Fixtures for Rock and Type resources to seed database with rock and type data
- Defined RockTypeSerializer to serialize the Type field in the RockSerializer & return a nested type object with the label value

## Testing via Postman
GET request to `/types` now returns an list of Type dictionaries
**Request**
```json
{
     "Authorization": "Token: {token}"
}
```
**Response**
200 OK status
```json
[
    {
        "id": 1,
        "label": "Metamorphic"
    },
    {
        "id": 2,
        "label": "Igneous"
    },
    {
        "id": 3,
        "label": "Sedimentary"
    },
    {
        "id": 4,
        "label": "Shale"
    },
    {
        "id": 5,
        "label": "Basalt"
    }
]
```

GET requests to `/rocks` now returns a list of rock dictionaries with expanded/nested type dictionaries
**Request**
```json
{
     "Authorization": "Token: {token}"
}
```
**Response**
```json
[
    {
        "id": 1,
        "name": "Tiana",
        "weight": "1.30",
        "user": 1,
        "type": {
            "label": "Sedimentary"
        }
    },
    {
        "id": 2,
        "name": "Orpha",
        "weight": "0.50",
        "user": 1,
        "type": {
            "label": "Metamorphic"
        }
    },
    {
        "id": 3,
        "name": "Sasha",
        "weight": "0.29",
        "user": 1,
        "type": {
            "label": "Basalt"
        }
    }
]
```