### PR TITLE
Created fixtures for Rock and Type resources | created RockType seria…

### DIFF
--- a/rockapi/fixtures/rocks.json
+++ b/rockapi/fixtures/rocks.json
@@ -1,0 +1,32 @@
+[
+    {
+        "model": "rockapi.rock",
+        "pk": 1,
+        "fields": {
+            "user": 1,
+            "type": 3,
+            "name": "Tiana",
+            "weight": 1.3
+        }
+    },
+    {
+        "model": "rockapi.rock",
+        "pk": 2,
+        "fields": {
+            "user": 1,
+            "type": 1,
+            "name": "Orpha",
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "rockapi.rock",
+        "pk": 3,
+        "fields": {
+            "user": 1,
+            "type": 5,
+            "name": "Sasha",
+            "weight": 0.29
+        }
+    }
+]

--- a/rockapi/fixtures/types.json
+++ b/rockapi/fixtures/types.json
@@ -1,0 +1,37 @@
+[
+    {
+        "model": "rockapi.type",
+        "pk": 1,
+        "fields": {
+            "label": "Metamorphic"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 2,
+        "fields": {
+            "label": "Igneous"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 3,
+        "fields": {
+            "label": "Sedimentary"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 4,
+        "fields": {
+            "label": "Shale"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 5,
+        "fields": {
+            "label": "Basalt"
+        }
+    }
+]

--- a/rockapi/views/rocks.py
+++ b/rockapi/views/rocks.py
@@ -2,7 +2,7 @@ from django.http import HttpResponseServerError
 from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from rockapi.models import Rock
+from rockapi.models import Rock, Type
 
 class RockView(ViewSet):
     """Rock view set"""
@@ -31,9 +31,18 @@ class RockView(ViewSet):
         except Exception as ex:
             return HttpResponseServerError(ex)
 
-class RockSerializer(serializers.ModelSerializer):
+class RockTypeSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
     class Meta:
+        model = Type
+        fields = ( 'label', )
+
+class RockSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    type = RockTypeSerializer(many=False)
+
+    class Meta:
         model = Rock
-        fields = ( 'id', 'name', 'weight', )
+        fields = ( 'id', 'name', 'weight', 'user', 'type', )


### PR DESCRIPTION
…lizer to return nested Type with label field in GET requests to '/rocks'

## Changes

- Created Fixtures for Rock and Type resources to seed database with rock and type data
- Defined RockTypeSerializer to serialize the Type field in the RockSerializer & return a nested type object with the label value

## Testing via Postman
GET request to `/types` now returns an list of Type dictionaries
**Request**
```json
{
     "Authorization": "Token: {token}"
}
```
**Response**
200 OK status
```json
[
    {
        "id": 1,
        "label": "Metamorphic"
    },
    {
        "id": 2,
        "label": "Igneous"
    },
    {
        "id": 3,
        "label": "Sedimentary"
    },
    {
        "id": 4,
        "label": "Shale"
    },
    {
        "id": 5,
        "label": "Basalt"
    }
]
```

GET requests to `/rocks` now returns a list of rock dictionaries with expanded/nested type dictionaries
**Request**
```json
{
     "Authorization": "Token: {token}"
}
```
**Response**
```json
[
    {
        "id": 1,
        "name": "Tiana",
        "weight": "1.30",
        "user": 1,
        "type": {
            "label": "Sedimentary"
        }
    },
    {
        "id": 2,
        "name": "Orpha",
        "weight": "0.50",
        "user": 1,
        "type": {
            "label": "Metamorphic"
        }
    },
    {
        "id": 3,
        "name": "Sasha",
        "weight": "0.29",
        "user": 1,
        "type": {
            "label": "Basalt"
        }
    }
]
```