### PR TITLE
Defined RockOwnerSerializer to return expanded user dictionary with f…

### DIFF
--- a/rockapi/views/rocks.py
+++ b/rockapi/views/rocks.py
@@ -3,6 +3,7 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from rockapi.models import Rock, Type
+from django.contrib.auth.models import User
 
 class RockView(ViewSet):
     """Rock view set"""
@@ -38,10 +39,18 @@ class RockTypeSerializer(serializers.ModelSerializer):
         model = Type
         fields = ( 'label', )
 
+class RockOwnerSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    class Meta:
+        model = User
+        fields = ( 'first_name', 'last_name', )
+
 class RockSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
     type = RockTypeSerializer(many=False)
+    user = RockOwnerSerializer(many=False)
 
     class Meta:
         model = Rock


### PR DESCRIPTION
…irst_name & last_name fields for requests to '/rocks'

## Testing via Postman
GET request to `/rocks`
**Request**
```json
{
     "Authorization": "Token {token}"
}
```
**Response**
200 OK status with list of rock dictionaries with expanded user dictionaries in response body
```json
[
    {
        "id": 1,
        "name": "Tiana",
        "weight": "1.30",
        "user": {
            "first_name": "Admina",
            "last_name": "Straytor"
        },
        "type": {
            "label": "Sedimentary"
        }
    },
    {
        "id": 2,
        "name": "Orpha",
        "weight": "0.50",
        "user": {
            "first_name": "Admina",
            "last_name": "Straytor"
        },
        "type": {
            "label": "Metamorphic"
        }
    },
    {
        "id": 3,
        "name": "Sasha",
        "weight": "0.29",
        "user": {
            "first_name": "Admina",
            "last_name": "Straytor"
        },
        "type": {
            "label": "Basalt"
        }
    }
]
```