### PR TITLE
Destroy() method for owner-allowed DELETE requests to '/rocks/{pk}'

### DIFF
--- a/rockapi/views/rocks.py
+++ b/rockapi/views/rocks.py
@@ -43,6 +43,26 @@ class RockView(ViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as ex:
             return HttpResponseServerError(ex)
+    
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests to remove a rock instance
+        
+        Returns:
+            204 No Content
+        """
+        try:
+            rock = Rock.objects.get(pk=pk)
+            if rock.user == request.auth.user:
+                rock.delete()
+                return Response(None, status=status.HTTP_204_NO_CONTENT)
+            else:
+                return Response({'message': 'You do not own that rock, shame!'}, status=status.HTTP_403_FORBIDDEN)
+
+        except Rock.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)        
 
 class RockTypeSerializer(serializers.ModelSerializer):
     """JSON serializer"""


### PR DESCRIPTION
## Changes

- Defined destroy() method in RockView class to handle DELETE requests to `/rocks/{pk}` to remove a rock instance from the database
- Only user who owns the rock can perform DELETE requests successfully

## Testing via Postman
DELETE requests to `/rocks/{pk}`
**Request**
```json
{
     "Authorization": "Token {token}"
}
```
**Response**
204 No Content: If resource exists and the rock belongs to the user making the delete request
OR
403 Forbidden: If rock does not belong to the user associated with token in request headers
```json
{
    "message": "You do not own that rock, shame!"
}
```