### PR TITLE
Added query params to filter rock list based on user ownership

### DIFF
--- a/rockapi/views/rocks.py
+++ b/rockapi/views/rocks.py
@@ -38,7 +38,13 @@ class RockView(ViewSet):
         """
 
         try:
+            owner_only = request.query_params.get('owner', None)
+
             rocks = Rock.objects.all()
+
+            if owner_only is not None and owner_only == "current":
+                rocks = rocks.filter(user=request.auth.user)
+                
             serializer = RockSerializer(rocks, many=True)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as ex:


### PR DESCRIPTION
## Changes

- If query param "owner=current" is sent in request url, API will filter rock list based on the user credentials to only return rocks that belong to that user

## Testing via Postman
**Request**
GET `/rocks?owner=current` for user-specific list of rock resources
```json
{
     "Authorization": "Token {token}"
}
```
**Response**
200 OK Status, returns a list of rock dictionaries belonging to the user with the authtoken sent in request headers
```json
[
    {
        "id": 4,
        "name": "Hob Goblin",
        "weight": "5.72",
        "user": {
            "first_name": "Steve",
            "last_name": "Brownlee"
        },
        "type": {
            "label": "Sedimentary"
        }
    },
    {
        "id": 5,
        "name": "Lizard Wizard",
        "weight": "542.00",
        "user": {
            "first_name": "Steve",
            "last_name": "Brownlee"
        },
        "type": {
            "label": "Shale"
        }
    },
    {
        "id": 7,
        "name": "Big Bold",
        "weight": "1.00",
        "user": {
            "first_name": "Steve",
            "last_name": "Brownlee"
        },
        "type": {
            "label": "Basalt"
        }
    },
    {
        "id": 8,
        "name": "Mr. Peb",
        "weight": "2.00",
        "user": {
            "first_name": "Steve",
            "last_name": "Brownlee"
        },
        "type": {
            "label": "Sedimentary"
        }
    },
    {
        "id": 9,
        "name": "Rocko",
        "weight": "5.76",
        "user": {
            "first_name": "Steve",
            "last_name": "Brownlee"
        },
        "type": {
            "label": "Shale"
        }
    }
]
```
